### PR TITLE
Use internationalization for visible text

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1,6 +1,22 @@
 {
+    "extensionName": {
+        "message": "Auditory Haptic Graphics Extension",
+        "description": "Extension name"
+    },
+    "extensionDescription": {
+        "message": "Extension for the McGill ATP project. This is a very, very, early alpha.",
+        "description": "Brief description of the extension. Will be expanded eventually."
+    },
     "menuItem": {
         "message": "Get ATP Rendering",
         "description": "Fetches ATP audio and haptic renderings for an image."
+    },
+    "renderingTitle": {
+        "message": "Renderings",
+        "description": "Header of popup window"
+    },
+    "renderingLabel": {
+        "message": "Rendering",
+        "description": "Label for each rendering returned from the server"
     }
 }

--- a/src/info/info.html
+++ b/src/info/info.html
@@ -4,7 +4,7 @@
     </head>
     <body>
         <header class="container">
-            <h1 class="title">Renderings</h1>
+            <h1 class="title" id="renderingTitle"></h1>
         </header>
         <script type="text/javascript" src="./info.ts"></script>
     </body>

--- a/src/info/info.ts
+++ b/src/info/info.ts
@@ -1,10 +1,19 @@
 import 'bootstrap';
 import 'bootstrap/dist/css/bootstrap.css';
+import { browser } from "webextension-polyfill-ts";
 import { v4 as uuidv4 } from 'uuid';
 
 let encodedRenderings = window.location.search.substring(1);
 let renderings = JSON.parse(decodeURIComponent(encodedRenderings));
 console.debug(renderings);
+
+// Update renderings label
+let title = document.getElementById("renderingTitle");
+if (title) {
+    title.textContent = browser.i18n.getMessage("renderingTitle");
+}
+
+let label = browser.i18n.getMessage("renderingLabel");
 
 let count = 1;
 for (let rendering of renderings["renderings"]) {
@@ -18,7 +27,7 @@ for (let rendering of renderings["renderings"]) {
     labelButton.setAttribute("data-bs-target", "#" + contentId);
     labelButton.setAttribute("aria-expanded", "false");
     labelButton.setAttribute("aria-controls", contentId);
-    labelButton.textContent = "Rendering " + count + ": " + rendering["text_string"];
+    labelButton.textContent = label + " " + count + ": " + rendering["text_string"];
     container.append(labelButton);
 
     let details = rendering["metadata"]["more_details_rendering"];

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,8 +1,8 @@
 {
     "manifest_version": 2,
-    "name": "Auditory Haptics Graphics Extension",
+    "name": "__MSG_extensionName__",
     "version": "0.0.1",
-    "description": "Extension for the AHG project. This is in a very, very early alpha.",
+    "description": "__MSG_extensionDescription__",
     "default_locale": "en",
 
     "permissions": [


### PR DESCRIPTION
For text produced by the extension (not by the server!), use the i18n API in WebExtensions. This allows us to update all text in an easy place and have it change depending on the user's requested language (making it easy to add French support).

All internationalized text is located under `src/_locales/[language tag]/messages.json` as a JSON file. To add support for other languages and locales, this only requires adding the directory for the proper code. See [the MDN documentation](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Internationalization) for more information.