### PR TITLE
Use original image size for most images and encode as JPEGs

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -22,10 +22,16 @@ port.onMessage.addListener(message => {
 
             const canvas = document.createElement("canvas");
             const ctx = canvas.getContext("2d");
-            canvas.width = imageElement.width;
-            canvas.height = imageElement.height;
-            ctx?.drawImage(imageElement, 0, 0);
-            const data = canvas.toDataURL();
+            //canvas.width = imageElement.width;
+            //canvas.height = imageElement.height;
+            // Fix for #30
+            canvas.width = imageElement.naturalWidth;
+            canvas.height = imageElement.naturalHeight;
+            console.debug(imageElement.naturalWidth);
+            // Fix for #30, specify size and use lossy format
+            ctx?.drawImage(imageElement, 0, 0, canvas.width, canvas.height);
+            const data = canvas.toDataURL("image/jpeg");
+            console.debug(data);
 
             port.postMessage({
                 "type": "resource",


### PR DESCRIPTION
This largely fixes #30 for now. The [naturalHeight and naturalWidth](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/naturalWidth) attributes *typically* contain the server-side dimensions of the image. This doesn't seem to be the case for structures like on Wikipedia, but it does appear to work for our demo images. Also, the encoding for images transferred to the server has been changed from PNG to JPEG to benefit from lossy compression. Some full size pictures in PNG would be 25 MB, which is frankly too big.