### PR TITLE
Remove crossorigin specification

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -18,7 +18,6 @@ port.onMessage.addListener(message => {
             } else {
                 imageElement = selectedElement?.querySelector("img") as HTMLImageElement;
             }
-            imageElement.setAttribute("crossorigin", "anonymous");
 
             const canvas = document.createElement("canvas");
             const ctx = canvas.getContext("2d");


### PR DESCRIPTION
This was added to prevent CORS problems, but instead seems to be causing
them and is unnecessary now that the extension has higher privileges.
Fixes #32.