### PR TITLE
Handle getting the image in the background script

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -18,27 +18,14 @@ port.onMessage.addListener(message => {
             } else {
                 imageElement = selectedElement?.querySelector("img") as HTMLImageElement;
             }
-            imageElement.setAttribute("crossorigin", "anonymous");
-
-            const canvas = document.createElement("canvas");
-            const ctx = canvas.getContext("2d");
-            //canvas.width = imageElement.width;
-            //canvas.height = imageElement.height;
-            // Fix for #30
-            canvas.width = imageElement.naturalWidth;
-            canvas.height = imageElement.naturalHeight;
-            console.debug(imageElement.naturalWidth);
-            // Fix for #30, specify size and use lossy format
-            ctx?.drawImage(imageElement, 0, 0, canvas.width, canvas.height);
-            const data = canvas.toDataURL("image/jpeg");
-            console.debug(data);
-
+            console.debug(imageElement.currentSrc);
+            console.debug(port);
             port.postMessage({
                 "type": "resource",
                 "context": selectedElement ? serializer.serializeToString(selectedElement) : null,
-                "image": data,
-                "dims": [ canvas.width, canvas.height ],
-                "url": window.location.href
+                "dims": [ imageElement.naturalWidth, imageElement.naturalHeight ],
+                "url": window.location.href,
+                "sourceURL": imageElement.currentSrc
             });
             break;
         default:


### PR DESCRIPTION
This has us download the image again, but if we're doing it in the background script we are free from CORS restrictions given the privileges we request for the extension. Note that this will only work for images that have an accessible URL. Images generated in the page or that require authentication will break, but there doesn't seem to be a good way around that right now.

Fix #32.