### PR TITLE
Use Ports to Communicate with Info Page

### DIFF
--- a/src/info/info.ts
+++ b/src/info/info.ts
@@ -5,68 +5,71 @@ import { v4 as uuidv4 } from 'uuid';
 import { IMAGEResponse } from "../types/response.schema";
 
 let request_uuid = window.location.search.substring(1);
-let renderingText = window.localStorage.getItem(request_uuid);
 let renderings: IMAGEResponse;
-if (renderingText) {
-    renderings = JSON.parse(renderingText);
-} else {
-    renderings = { "request_uuid": request_uuid, "timestamp": 0, "renderings": [] };
-}
-console.debug(renderings);
-
-window.onunload = () => {
-    window.localStorage.removeItem(request_uuid);
-};
-
-// Update renderings label
-let title = document.getElementById("renderingTitle");
-if (title) {
-    title.textContent = browser.i18n.getMessage("renderingTitle");
-}
-
-let label = browser.i18n.getMessage("renderingLabel");
-
-let count = 1;
-for (let rendering of renderings["renderings"]) {
-    let container = document.createElement("section");
-    container.classList.add("container");
-    let labelButton = document.createElement("button");
-    let contentId = "m-" + uuidv4();
-    labelButton.classList.add("btn", "btn-primary");
-    labelButton.setAttribute("type", "button");
-    labelButton.setAttribute("data-bs-toggle", "collapse");
-    labelButton.setAttribute("data-bs-target", "#" + contentId);
-    labelButton.setAttribute("aria-expanded", "false");
-    labelButton.setAttribute("aria-controls", contentId);
-    labelButton.textContent = label + " " + count + ": " + rendering["description"];
-    container.append(labelButton);
-
-    if (rendering["type_id"] === "ca.mcgill.cim.bach.atp.renderer.Text") {
-        let div = document.createElement("div");
-        div.classList.add("row");
-        container.append(div);
-        let contentDiv = document.createElement("div");
-        contentDiv.classList.add("collapse");
-        contentDiv.id = contentId;
-        div.append(contentDiv);
-        const text = rendering["data"]["text"] as string;
-        const p = document.createElement("p");
-        p.textContent = text;
-        contentDiv.append(p);
+let port = browser.runtime.connect();
+port.onMessage.addListener(message => {
+    if (message) {
+        renderings = message;
+    } else {
+        renderings = { "request_uuid": request_uuid, "timestamp": 0, "renderings": [] };
     }
-    else if (rendering["type_id"] === "ca.mcgill.cim.bach.atp.renderer.SimpleAudio") {
-        let div = document.createElement("div");
-        div.classList.add("row");
-        container.append(div);
-        let contentDiv = document.createElement("div");
-        contentDiv.classList.add("collapse");
-        contentDiv.id = contentId;
-        div.append(contentDiv);
-        const audio = document.createElement("audio");
-        audio.setAttribute("controls", "");
-        audio.setAttribute("src", rendering["data"]["audio"] as string);
-        contentDiv.append(audio);
+    console.debug(renderings);
+
+    // Update renderings label
+    let title = document.getElementById("renderingTitle");
+    if (title) {
+        title.textContent = browser.i18n.getMessage("renderingTitle");
     }
-    document.body.append(container);
-    count++;
-}
+
+    let label = browser.i18n.getMessage("renderingLabel");
+
+    let count = 1;
+    for (let rendering of renderings["renderings"]) {
+        let container = document.createElement("section");
+        container.classList.add("container");
+        let labelButton = document.createElement("button");
+        let contentId = "m-" + uuidv4();
+        labelButton.classList.add("btn", "btn-primary");
+        labelButton.setAttribute("type", "button");
+        labelButton.setAttribute("data-bs-toggle", "collapse");
+        labelButton.setAttribute("data-bs-target", "#" + contentId);
+        labelButton.setAttribute("aria-expanded", "false");
+        labelButton.setAttribute("aria-controls", contentId);
+        labelButton.textContent = label + " " + count + ": " + rendering["description"];
+        container.append(labelButton);
+
+        if (rendering["type_id"] === "ca.mcgill.cim.bach.atp.renderer.Text") {
+            let div = document.createElement("div");
+            div.classList.add("row");
+            container.append(div);
+            let contentDiv = document.createElement("div");
+            contentDiv.classList.add("collapse");
+            contentDiv.id = contentId;
+            div.append(contentDiv);
+            const text = rendering["data"]["text"] as string;
+            const p = document.createElement("p");
+            p.textContent = text;
+            contentDiv.append(p);
+        }
+        else if (rendering["type_id"] === "ca.mcgill.cim.bach.atp.renderer.SimpleAudio") {
+            let div = document.createElement("div");
+            div.classList.add("row");
+            container.append(div);
+            let contentDiv = document.createElement("div");
+            contentDiv.classList.add("collapse");
+            contentDiv.id = contentId;
+            div.append(contentDiv);
+            const audio = document.createElement("audio");
+            audio.setAttribute("controls", "");
+            audio.setAttribute("src", rendering["data"]["audio"] as string);
+            contentDiv.append(audio);
+        }
+        document.body.append(container);
+        count++;
+    }
+});
+
+port.postMessage({
+    "type": "info",
+    "request_uuid": request_uuid
+});


### PR DESCRIPTION
The info page opens a port to the background script and requests the response from the server for a certain rendering ID (passed as a parameter in the URL). The response is undefined if none exists. Before the response is requested, the response is stored in a map and deleted after being sent to the info page. It may be better to have this persist for some time to allow refreshes.

Fix #37.