### PR TITLE
Remove tabs permission

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -8,7 +8,6 @@
 
     "permissions": [
         "contextMenus",
-        "tabs",
         "downloads",
         "<all_urls>"
     ],


### PR DESCRIPTION
It doesn't seem that we actually need this permission for the extension to function. Removing additional permissions will help in terms of distributing our extension.