### PR TITLE
Enable context menu once loading is complete

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -150,7 +150,43 @@ function storeConnection(p: Runtime.Port) {
     }
 }
 
+/*Enable the context menu options*/
+function enableContextMenu(){
+    browser.contextMenus.update("mwe-item",{ enabled: true });
+    browser.contextMenus.update("preprocess-only",{ enabled: true });
+    browser.contextMenus.update("request-only",{ enabled: true });
+}
+
+/*Disable the context menu options*/
+function disableContextMenu(){
+    browser.contextMenus.update("mwe-item",{ enabled: false });
+    browser.contextMenus.update("preprocess-only",{ enabled: false });
+    browser.contextMenus.update("request-only",{ enabled: false });
+}
+
+/*Handle the context menu items based on the status of the DOM*/
+function handleUpdated(tabId: any, changeInfo: any) {
+  if (changeInfo.status == "complete"){
+    enableContextMenu();
+  }else if (changeInfo.status == "unloaded" || changeInfo.status == "loading"){
+    disableContextMenu();
+  }
+}
+
+/*Handle context menu items based on DOM for the active Tab*/
+function getCurrentTabInfo(){
+    let currentTab = browser.tabs.query({currentWindow: true, active: true});
+    currentTab.then(
+        function(tabs){
+            handleUpdated(tabs[0].id, tabs[0]);
+        },
+        function(error){console.log(error)}
+    );
+}
+
 browser.runtime.onConnect.addListener(storeConnection);
+browser.tabs.onUpdated.addListener(handleUpdated);
+browser.tabs.onActivated.addListener(getCurrentTabInfo);
 
 function onCreated(): void {
     if (browser.runtime.lastError) {
@@ -161,7 +197,7 @@ function onCreated(): void {
 browser.contextMenus.create({
     id: "mwe-item",
     title: browser.i18n.getMessage("menuItem"),
-    contexts: ["image", "link"],
+    contexts: ["image", "link"]
 },
 onCreated);
 browser.contextMenus.create({


### PR DESCRIPTION
The Pull request includes fix for issue #70. The context menu items will be disabled till the DOM is loading, Once the page has been completely loaded, only then it is possible for the user to make the requests to IMAGE server.