### PR TITLE
Generate git tags and artifacts on merge in main branch

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,19 @@
+name: Bump version
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
+
+    - name: Bump version and push tag
+      uses: anothrNick/github-tag-action@1.36.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DEFAULT_BUMP: patch
+        WITH_V: true

--- a/.github/workflows/typescript-check.yml
+++ b/.github/workflows/typescript-check.yml
@@ -44,8 +44,8 @@ jobs:
         run: npm ci
       - name: Pack extension
         run: npm run pack
-      - name: Save as artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: extension
-          path: build
+      # - name: Save as artifact
+      #   uses: actions/upload-artifact@v2
+      #   with:
+      #     name: extension
+      #     path: build


### PR DESCRIPTION
The PR includes a fix for #107 . 
Note that I am commenting out the existing upload artifacts action, since there is no point in duplicating the artifacts. And, I could not find a way to get the links of the artifacts uploaded by this action once the workflow is over.
After this PR, all the git tags and the artifacts should appear here: https://github.com/Shared-Reality-Lab/IMAGE-browser/tags.
But I am open to suggestions here, if @JRegimbal or @jeffbl have a better way of handling this, please let me know. I can implement the changes accordingly.