### PR TITLE
Fixing bug for refreshing page after saving settings

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -4,7 +4,7 @@
         "description": "Extension name"
     },
     "extensionDescription": {
-        "message": "Extension for the McGill IMAGE project. This is a very, very, early alpha.",
+        "message": "Extension for the McGill IMAGE project. This is a beta release.",
         "description": "Brief description of the extension. Will be expanded eventually."
     },
     "menuItem": {

--- a/src/background.ts
+++ b/src/background.ts
@@ -120,6 +120,7 @@ async function handleMessage(p: Runtime.Port, message: any) {
     case "resource":
     case "localResource":
     case "mapResource":
+    case "settingsSaved":
       // Get response and open new window
       if (message["type"] === "resource") {
         query = await generateQuery(message);
@@ -208,11 +209,54 @@ async function handleMessage(p: Runtime.Port, message: any) {
             console.error(err);
         });
       }
+      if(message["type"]==="settingsSaved"){
+        updateDebugContextMenu();
+      }
       break;
     default:
       console.debug(message["type"]);
       break;
   }
+}
+
+
+function updateDebugContextMenu(){
+  getAllStorageSyncData().then((items) => {
+    showDebugOptions = items["developerMode"];
+    previousToggleState = items["previousToggleState"];
+
+    if (showDebugOptions) {
+      if(items["processItem"] === "" && items["requestItem"] === ""){
+          browser.contextMenus.create({
+            id: "preprocess-only",
+            title: browser.i18n.getMessage("preprocessItem"),
+            contexts: ["image", "link"]
+          },
+        onCreated);
+        browser.contextMenus.create({
+          id: "request-only",
+          title: browser.i18n.getMessage("requestItem"),
+          contexts: ["image", "link"]
+        },
+        onCreated);
+      }
+  
+      browser.storage.sync.set({
+        previousToggleState : true,
+        processItem: "preprocess-only",
+        requestItem: "request-only",
+      })
+    }
+    else if(showDebugOptions === false && previousToggleState) {
+      browser.contextMenus.remove("preprocess-only");
+      browser.contextMenus.remove("request-only");
+      browser.storage.sync.set({previousToggleState : false});
+      browser.storage.sync.set({
+        processItem: "",
+        requestItem: "",
+      })
+    }
+  });
 }
 
 function storeConnection(p: Runtime.Port) {
@@ -276,27 +320,25 @@ function onCreated(): void {
         console.error(browser.runtime.lastError);
     }
 }
+
+browser.contextMenus.create({
+    id: "mwe-item",
+    title: browser.i18n.getMessage("menuItem"),
+    contexts: ["image", "link"]
+},
+onCreated);
+browser.storage.sync.set({
+  mweItem:"mwe-item"
+})
+
 var showDebugOptions: Boolean;
+var previousToggleState: Boolean;
 
 getAllStorageSyncData().then((items) => {
   showDebugOptions = items["developerMode"];
-  const previousToggleState = items["previousToggleState"];
-
-  if(items["mweItem"] === ""){
-    browser.contextMenus.create({
-        id: "mwe-item",
-        title: browser.i18n.getMessage("menuItem"),
-        contexts: ["image", "link"]
-    },
-    onCreated);
-    browser.storage.sync.set({
-      mweItem:"mwe-item"
-    })
-  }
- 
+  previousToggleState = items["previousToggleState"];
 
   if (showDebugOptions) {
-    if(items["processItem"] === "" && items["requestItem"] === ""){
         browser.contextMenus.create({
           id: "preprocess-only",
           title: browser.i18n.getMessage("preprocessItem"),
@@ -310,23 +352,6 @@ getAllStorageSyncData().then((items) => {
       },
       onCreated);
     }
-
-  browser.storage.sync.set({
-    previousToggleState : true,
-    processItem: "preprocess-only",
-    requestItem: "request-only",
-  })
-}
-
-  else if(showDebugOptions === false && previousToggleState) {
-    browser.contextMenus.remove("preprocess-only");
-    browser.contextMenus.remove("request-only");
-    browser.storage.sync.set({previousToggleState : false});
-    browser.storage.sync.set({
-      processItem: "",
-      requestItem: "",
-    })
-  }
 });
 
 browser.contextMenus.onClicked.addListener((info, tab) => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -181,7 +181,13 @@ async function handleMessage(p: Runtime.Port, message: any) {
       }
       else if (message["toRender"] === "preprocess") {
           await getAllStorageSyncData().then(async items => {
-            serverUrl = items["inputUrl"];
+            if(items["mcgillServer"]===true){
+              serverUrl = "https://image.a11y.mcgill.ca/";
+            }else{
+              if(items["inputUrl"]!== "" && items["customServer"]===true){
+              serverUrl = items["inputUrl"];
+              }
+            }
             browser.downloads.download({
             url: serverUrl + "render/preprocess",
             headers: [{ name: "Content-Type", value: "application/json" }],
@@ -316,6 +322,10 @@ getAllStorageSyncData().then((items) => {
     browser.contextMenus.remove("preprocess-only");
     browser.contextMenus.remove("request-only");
     browser.storage.sync.set({previousToggleState : false});
+    browser.storage.sync.set({
+      processItem: "",
+      requestItem: "",
+    })
   }
 });
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extensionName__",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "description": "__MSG_extensionDescription__",
     "homepage_url": "https://image.a11y.mcgill.ca",
     "default_locale": "en",

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -50,8 +50,6 @@ const customServerSetting = <HTMLInputElement>(document.getElementById("custom-s
 //   }
 // }
 
-var result : String|null;
-
 function customUrlCheck(){
   browser.storage.sync.get({
     inputUrl: "",
@@ -59,7 +57,7 @@ function customUrlCheck(){
   })
   .then((items)=>{
     if(items["inputUrl"]==="" && items["customServer"]=== true){
-    window.alert("Continuing without entering Custom URL will not give any renderings");
+    window.alert("Continuing without entering Custom URL will not give any renderings.");
     }else{
      window.alert("Preferences Saved!");
     }

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -16,6 +16,8 @@
  */
 import  browser  from "webextension-polyfill";
 
+let port = browser.runtime.connect();
+
 // Set up localized names
 const labels = Array.from(document.querySelectorAll("label"));
 for (let label of labels) {
@@ -48,6 +50,22 @@ const customServerSetting = <HTMLInputElement>(document.getElementById("custom-s
 //   }
 // }
 
+var result : String|null;
+
+function customUrlCheck(){
+  browser.storage.sync.get({
+    inputUrl: "",
+    customServer:false,
+  })
+  .then((items)=>{
+    if(items["inputUrl"]==="" && items["customServer"]=== true){
+    window.alert("Continuing without entering Custom URL will not give any renderings");
+    }else{
+     window.alert("Preferences Saved!");
+    }
+  });
+}
+
 function saveOptions() {
   browser.storage.sync.set({
     inputUrl: (<HTMLInputElement>document.getElementById("input-url")).value,
@@ -58,11 +76,11 @@ function saveOptions() {
     //haply2diy: haply2diySetting.checked
   }),
     (function () {
-   window.alert("Preferences Saved!");
-      browser.runtime.getBackgroundPage().then((res) => {
-        res.location.reload();
-      })
-    })();
+    customUrlCheck();
+    port.postMessage({
+      type: "settingsSaved"
+    });
+  })();
 }
 
 function restore_options() {


### PR DESCRIPTION
This PR fixes the bug that removes the context menu upon extension reload. It also adds the functionality of getting renderings without reloading the target tab/window.

