### PR TITLE
Override seeking in Plyr with segment-driven behavior

### DIFF
--- a/src/info/info.ts
+++ b/src/info/info.ts
@@ -120,7 +120,9 @@ port.onMessage.addListener(async (message) => {
             download.textContent = "Download Audio File";
             contentDiv.append(download);
             const audioInfo = rendering["data"]["audioInfo"] as { "name": string, "offset": number, "duration": number }[];
-            player.on("keydown", (e: KeyboardEvent) => {
+            // eslint-disable-next-line
+            // @ts-ignore
+            player.on("keypress", (e: KeyboardEvent) => {
                 if (e.key === "ArrowLeft") {
                     // Get previous segment
                     let i = 0;

--- a/src/info/info.ts
+++ b/src/info/info.ts
@@ -122,7 +122,7 @@ port.onMessage.addListener(async (message) => {
             const audioInfo = rendering["data"]["audioInfo"] as { "name": string, "offset": number, "duration": number }[];
             // eslint-disable-next-line
             // @ts-ignore
-            player.on("keypress", (e: KeyboardEvent) => {
+            player.on("keydown", (e: KeyboardEvent) => {
                 if (e.key === "ArrowLeft") {
                     // Get previous segment
                     let i = 0;


### PR DESCRIPTION
This should resolve #141 as currently defined. The SegmentAudio display is rewritten to make use of Plyr with two major changes:
1. seek length for arrow keys is set to 0 (default: 10 s)
2. a new listener is added to jump to the next identified audio segment on left/right arrow presses.

This works locally with the current deployment on Pegasus. Assigning to @Cybernide  and @Sabrina-Knappe to check behavior correctness

~Below is a video showing seeking behavior using left/right arrow keys.~
Audio isn't playing when uploaded so sending over slack.