### PR TITLE
Replace schema "image" with "graphic"

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -28,7 +28,7 @@ function getAllStorageSyncData() {
     //Default values
     inputUrl: "",
     customServer:false,
-    mcgillServer: true, 
+    mcgillServer: true,
     developerMode: false,
     previousToggleState:false,
     processItem: "",
@@ -56,7 +56,7 @@ async function generateQuery(message: { context: string, url: string, dims: [num
             "request_uuid": uuidv4(),
             "timestamp": Math.round(Date.now() / 1000),
             "URL": message.url,
-            "image": image,
+            "graphic": image,
             "dimensions": message.dims,
             "context": message.context,
             "language": "en",
@@ -110,7 +110,7 @@ function generateLocalQuery(message: { context: string, dims: [number, number], 
     return {
         "request_uuid": uuidv4(),
         "timestamp": Math.round(Date.now() / 1000),
-        "image": message.image,
+        "graphic": message.image,
         "dimensions": message.dims,
         "context": message.context,
         "language": "en",
@@ -259,7 +259,7 @@ function updateDebugContextMenu(){
         },
         onCreated);
       }
-  
+
       browser.storage.sync.set({
         previousToggleState : true,
         processItem: "preprocess-only",

--- a/src/info/info.ts
+++ b/src/info/info.ts
@@ -186,7 +186,7 @@ port.onMessage.addListener(async (message) => {
             var firstCall: boolean = true;
 
             // get data from the handler
-            const imageSrc = rendering["data"]["image"] as string;
+            const imageSrc = rendering["data"]["graphic"] as string;
             const data = rendering["data"]["data"] as Array<JSON>;
 
             // add rendering button

--- a/src/types/request.schema.d.ts
+++ b/src/types/request.schema.d.ts
@@ -6,7 +6,7 @@
  */
 
 /**
- * Request for renderings of an image or a map given certain conditions.
+ * Request for renderings of a graphic or a map given certain conditions.
  */
 export type IMAGERequest = IMAGERequest1 & IMAGERequest2;
 export type IMAGERequest2 = {
@@ -23,11 +23,11 @@ export interface IMAGERequest1 {
    */
   timestamp?: number;
   /**
-   * Data URL of the base 64 image being handled.
+   * Data URL of the base 64 graphic being handled.
    */
-  image?: string;
+  graphic?: string;
   /**
-   * The width and height of the image as requested in pixels.
+   * The width and height of the graphic as requested in pixels.
    */
   dimensions?: [number, number];
   /**
@@ -43,7 +43,7 @@ export interface IMAGERequest1 {
    */
   placeID?: string;
   /**
-   * Serialized XML of the image node and possibly related nodes.
+   * Serialized XML of the source node and possibly related nodes.
    */
   context?: string;
   /**

--- a/src/types/response.schema.d.ts
+++ b/src/types/response.schema.d.ts
@@ -6,7 +6,7 @@
  */
 
 /**
- * Response of renderings of an image given certain conditions.
+ * Response of renderings of a graphic given certain conditions.
  */
 export interface IMAGEResponse {
   /**


### PR DESCRIPTION
This is the extension part of Shared-Reality-Lab/IMAGE-server#224. This is meant to only rename the "image" key in requests and in the haptics renderer to "graphic" to reflect schema changes. All other parts should be unmodified. This should not be merged until Shared-Reality-Lab/IMAGE-server#313 and Shared-Reality-Lab/IMAGE-server#322 are also ready to avoid parts coming out of sync.