### PR TITLE
Browser detection using webserial for Haptics

### DIFF
--- a/src/options/options.css
+++ b/src/options/options.css
@@ -1,56 +1,58 @@
-
- #preferences-submit {
-    background: #2196f3 ; 
-    border: none;
-    border-radius: 12px;
-    color: white;
-    display: inline-block;
-    font-size: 14px;
-    font-weight: 400;
-    margin-top: 20px;
-    text-decoration: none;
-    width: 140px; 
-    height: 40px; 
+#preferences-submit {
+  background: #2196f3 ; 
+  border: none;
+  border-radius: 12px;
+  color: white;
+  display: inline-block;
+  font-size: 14px;
+  font-weight: 400;
+  margin-top: 20px;
+  text-decoration: none;
+  width: 140px; 
+  height: 40px; 
 }
 
 #input-url{
-    height: 10px;
-    width: 500px;
-    font-size:12pt;
-    margin-left: 16px;
-    color: grey;
+  height: 30px;
+  width: 500px;
+  font-size:12pt;
+  margin-left: 16px;
+  color: grey;
 }
 
 #wrapper-div{
-    position:relative;
-    top:0px; 
-    overflow:auto;
+  position:relative;
+  top:0px; 
+  overflow:auto;
+}
+
+#developer-mode-text{
+color: grey;
+font-size: x-large;
+font-weight: 400;
 }
 
 #developer-mode{
-  float: left;
-  color: grey;
-  font-size: medium;
-  font-weight: 400;
+float:left;
 }
 
 #div-togglebutton{
-    margin-top: 17px;
-    left: 10px;
+margin-top: 17px;
+left: 10px;
 }
 .toggle-container {
-    position:relative;
-    display: inline-block;
-    width: 50px;
-    height: 25px;
-    pointer-events: none;
-  }
+  position:relative;
+  display: inline-block;
+  width: 50px;
+  height: 25px;
+  pointer-events: none;
+}
 
 .toggle-container input {
-  opacity: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: all;
+opacity: 0;
+width: 100%;
+height: 100%;
+pointer-events: all;
 }
 
 .slider {
@@ -66,109 +68,111 @@ pointer-events: none;
 }
 
 .slider::before {
-  content: "";
-  position: absolute;
-  height: 20px;
-  width: 20px;
-  left: 2px;
-  bottom: 2px;
-  background-color: #fff;
-  transition: 0.2s;
-  pointer-events: none;
+content: "";
+position: absolute;
+height: 20px;
+width: 20px;
+left: 2px;
+bottom: 2px;
+background-color: #fff;
+transition: 0.2s;
+pointer-events: none;
 }
 
 .slider::after {
-  position: absolute;
-  height: 20px;
-  width: 12px;
-  right: 5px;
-  bottom: 5px;
-  transition: 0.2s;
-  pointer-events: none;
-  color: #fff;
+position: absolute;
+height: 20px;
+width: 12px;
+right: 5px;
+bottom: 5px;
+transition: 0.2s;
+pointer-events: none;
+color: #fff;
 }
 
 input:checked + .slider {
-  background-color: #2196f3;
+background-color: #2196f3;
 }
 
 input:checked + .slider:before {
-  transform: translateX(25px);
+transform: translateX(25px);
 }
 
 input:checked + .slider:after {
-  left: 8px;
+left: 8px;
 }
 
-
 .slider.round {
-  border-radius: 34px;
+border-radius: 34px;
 }
 
 .slider.round:before {
-  border-radius: 50%;
+border-radius: 50%;
 }
 
 #advanced-options{
-  color: grey;
-  font-size: x-large;
-  font-weight: 400;
+color: grey;
+font-size: x-large;
+font-weight: 400;
 }
 
-/*#renderings-header{
-  color: grey;
-  font-size: x-large;
-  font-weight: 400;
+#renderings-header{
+color: grey;
+font-size: x-large;
+font-weight: 400;
 }
 #noHaptics{
-  color: grey;
-  font-size: medium;
-  font-weight: 400; 
+color: grey;
+font-size: medium;
+font-weight: 400; 
 }
 
 #Haply2diy{
-  color: grey;
-  font-size: medium;
-  font-weight: 400; 
+color: grey;
+font-size: medium;
+font-weight: 400; 
 }
 #audioRenderingsLabel{
-  color: grey;
-  font-size: medium;
-  font-weight: 400;
+color: grey;
+font-size: medium;
+font-weight: 400;
 }
 
 #textRenderingsLabel{
-  color: grey;
-  font-size: medium;
-  font-weight: 400;
-  line-height: 30pt;
-}*/
+color: grey;
+font-size: medium;
+font-weight: 400;
+line-height: 30pt;
+}
 
 #server-options{
-  color: grey;
-  font-size: medium;
-  font-weight: 400;
+color: grey;
+font-size: medium;
+font-weight: 400;
 }
 
 #mcgillServerLabel{
-  color: grey;
-  font-size: medium;
-  font-weight: 400; 
-  line-height: 30pt;
+color: grey;
+font-size: medium;
+font-weight: 400; 
+line-height: 30pt;
 }
 
 #customServerLabel{
-  color: grey;
-  font-size: medium;
-  font-weight: 400; 
-  line-height: 20pt;
+color: grey;
+font-size: medium;
+font-weight: 400; 
+line-height: 20pt;
 }
 
 #debugText{
-  color: grey;
-  font-size: medium;
-  font-weight: 400; 
+color: grey;
+font-size: medium;
+font-weight: 400; 
+margin-left: 0px;
 }
 
-
-
+#debug-text-div{
+text-align: start;
+margin-top: 20px;
+}

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -4,11 +4,8 @@
         <link rel="stylesheet" href="./options.css">
     </head>
     <body>
-
-    <!--
         <div>
            <h1 id="renderings-header">Rendering Options</h1> 
-            <h3>(Not yet Implemented)</h3> 
             <div class="browser-style">
                 <input type="checkbox" id="audio-renderings" name="audio-renderings">
                 <label for="audioRenderingsLabel" id="audioRenderingsLabel"></label>
@@ -18,7 +15,6 @@
                 <label for="textRenderingsLabel" id="textRenderingsLabel"></label>
             </div>
         </div>
-    -->
 
         <div id="wrapper-div">
             <h1 id="advanced-options">Advanced Options</h1> 
@@ -35,19 +31,19 @@
                 </div>
             </div> 
              
-            <div id = "developer-mode"><h1>Developer Mode</h1></div>
+            <div id = "developer-mode">
+                <h1 id = "developer-mode-text">Developer Mode</h1>
+            </div>
             <div id= "div-togglebutton" class="toggle-container">
                 <input type="checkbox" id = "toggle"/>
                 <div class="slider round"></div>
             </div>
-            <div>
+            <div id = "debug-text-div">
                 <h3 id="debugText">Enabling developer mode allows access to debug options from the context menu in the browser.</h1>
             </div>
        </div>
 
-    <!--
         <div id="developerSettingsDiv" style="display: none;">
-          <h3>(Not yet Implemented)</h3> 
             <div class="browser-style">
                 <input type="radio" id="none-option" name="none-option" checked>
                 <label for="noHaptics" id="noHaptics"></label>
@@ -57,7 +53,7 @@
                 <label for="Haply2diy" id="Haply2diy"></label>
             </div>
         </div>
-    -->
+    
         <button class="browser-style" type="submit" id="preferences-submit"></button>
         <div id="status"></div>
     </body>

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -17,9 +17,7 @@
 import  browser  from "webextension-polyfill";
 
 let port = browser.runtime.connect();
-let userAgentString = navigator.userAgent;
-let chromeAgent = userAgentString.indexOf("Chrome") > -1;
-
+let navigatorSerial =navigator.serial;
 // Set up localized names
 const labels = Array.from(document.querySelectorAll("label"));
 for (let label of labels) {
@@ -45,7 +43,7 @@ if (toggleButton) {
 }
 
 function showDeveloperSettings() {
-if (toggleButton.checked && chromeAgent===true) {
+if (toggleButton.checked && navigatorSerial !== undefined) {
     developerSettings.style.display = "block";
   } else {
     developerSettings.style.display = "none";
@@ -97,18 +95,18 @@ function restore_options() {
       haply2diy:false
     })
     .then((items) => {
-      (<HTMLInputElement>document.getElementById("input-url")).value =
-        items["inputUrl"];
-        mcgillServerSetting.checked = items["mcgillServer"];
-        customServerSetting.checked = items["customServer"];
-        toggleButton.checked = items["developerMode"];
-        noHapticsSetting.checked= items["noHaptics"];
-        haply2diySetting.checked= items["haply2diy"];
+    (<HTMLInputElement>document.getElementById("input-url")).value =
+      items["inputUrl"];
+      mcgillServerSetting.checked = items["mcgillServer"];
+      customServerSetting.checked = items["customServer"];
+      toggleButton.checked = items["developerMode"];
+      noHapticsSetting.checked= items["noHaptics"];
+      haply2diySetting.checked= items["haply2diy"];
 
-        if (toggleButton.checked && chromeAgent===true) {
-          developerSettings.style.display = "block"; 
-        }
-    }); 
+      if (toggleButton.checked && navigatorSerial !== undefined) {
+        developerSettings.style.display = "block"; 
+      }
+  }); 
 }
 
 document.addEventListener("DOMContentLoaded", restore_options);

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -17,7 +17,8 @@
 import  browser  from "webextension-polyfill";
 
 let port = browser.runtime.connect();
-let navigatorSerial =navigator.serial;
+let navigatorSerial = navigator.serial;
+
 // Set up localized names
 const labels = Array.from(document.querySelectorAll("label"));
 for (let label of labels) {
@@ -35,6 +36,8 @@ const customServerSetting = <HTMLInputElement>(document.getElementById("custom-s
 const developerSettings = <HTMLInputElement>(document.getElementById("developerSettingsDiv"));
 const noHapticsSetting = <HTMLInputElement>(document.getElementById("none-option"));
 const haply2diySetting =  <HTMLInputElement>(document.getElementById("haply-option"));
+const audioRenderingsSetting =  <HTMLInputElement>(document.getElementById("audio-renderings"));
+const textRenderingsSetting = <HTMLInputElement>(document.getElementById("text-renderings"));
 
 if (toggleButton) {
   toggleButton?.addEventListener("click", showDeveloperSettings);
@@ -50,16 +53,22 @@ if (toggleButton.checked && navigatorSerial !== undefined) {
   }
 }
 
-
-function customUrlCheck(){
+function optionsCheck(){
   browser.storage.sync.get({
     inputUrl: "",
     customServer:false,
+    noHaptics:true,
+    audio:false,
+    text:false
   })
   .then((items)=>{
-    if(items["inputUrl"]==="" && items["customServer"]=== true){
+    if(items["inputUrl"]=== "" && items["customServer"]=== true){
     window.alert("Continuing without entering Custom URL will not give any renderings.");
-    }else{
+    } 
+    else if(items["noHaptics"]=== true && items["audio"]=== false && items["text"]=== false ){
+      window.alert("No interpretations will appear when both Audio and Text are unchecked!");
+    }
+    else{
      window.alert("Preferences Saved!");
     }
   });
@@ -72,14 +81,16 @@ function saveOptions() {
     customServer: customServerSetting.checked,
     developerMode: toggleButton.checked,
     noHaptics: noHapticsSetting.checked,
-    haply2diy: haply2diySetting.checked
+    haply2diy: haply2diySetting.checked,
+    audio:audioRenderingsSetting.checked,
+    text:textRenderingsSetting.checked
   }),
     (function () {
-    customUrlCheck();
-    port.postMessage({
-      type: "settingsSaved"
-    });
-  })();
+      optionsCheck();
+      port.postMessage({
+        type: "settingsSaved"
+      });
+    })();
 }
 
 function restore_options() {
@@ -92,30 +103,44 @@ function restore_options() {
       previousToggleState:false,
       developerMode: false,
       noHaptics:true,
-      haply2diy:false
+      haply2diy:false,
+      audio:true,
+      text:false
     })
     .then((items) => {
-    (<HTMLInputElement>document.getElementById("input-url")).value =
-      items["inputUrl"];
-      mcgillServerSetting.checked = items["mcgillServer"];
-      customServerSetting.checked = items["customServer"];
-      toggleButton.checked = items["developerMode"];
-      noHapticsSetting.checked= items["noHaptics"];
-      haply2diySetting.checked= items["haply2diy"];
+      (<HTMLInputElement>document.getElementById("input-url")).value =
+        items["inputUrl"];
+        mcgillServerSetting.checked = items["mcgillServer"];
+        customServerSetting.checked = items["customServer"];
+        toggleButton.checked = items["developerMode"];
+        noHapticsSetting.checked= items["noHaptics"];
+        haply2diySetting.checked= items["haply2diy"];
+        audioRenderingsSetting.checked = items["audio"];
+        textRenderingsSetting.checked = items["text"];
 
-      if (toggleButton.checked && navigatorSerial !== undefined) {
-        developerSettings.style.display = "block"; 
-      }
-  }); 
+        if (toggleButton.checked &&  navigatorSerial !== undefined) {
+          developerSettings.style.display = "block"; 
+        }
+    }); 
 }
 
 document.addEventListener("DOMContentLoaded", restore_options);
 
-const submit = <HTMLInputElement>(document.getElementById("preferences-submit"));
+const submit = document.getElementById("preferences-submit");
+const cancel = document.getElementById("cancel-button");
 
 if (submit) {
-  submit.textContent = browser.i18n.getMessage("savePreferences");
+  submit.textContent = browser.i18n.getMessage("saveChanges");
   submit?.addEventListener("click", saveOptions);
 } else {
   console.warn('Could not find submit button with ID "preferences-submit"');
+}
+
+function reload(){
+  window.location.reload();
+}
+
+if(cancel){
+  cancel?.addEventListener("click", reload
+  );
 }

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -17,6 +17,8 @@
 import  browser  from "webextension-polyfill";
 
 let port = browser.runtime.connect();
+let userAgentString = navigator.userAgent;
+let chromeAgent = userAgentString.indexOf("Chrome") > -1;
 
 // Set up localized names
 const labels = Array.from(document.querySelectorAll("label"));
@@ -32,23 +34,24 @@ for (let label of labels) {
 const toggleButton = <HTMLInputElement>(document.getElementById("toggle"));
 const mcgillServerSetting = <HTMLInputElement>(document.getElementById("mcgill-server"));
 const customServerSetting = <HTMLInputElement>(document.getElementById("custom-server"));
-//const developerSettings = <HTMLInputElement>(document.getElementById("developerSettingsDiv"));
-//const noHapticsSetting = <HTMLInputElement>(document.getElementById("none-option"));
-//const haply2diySetting =  <HTMLInputElement>(document.getElementById("haply-option"));
+const developerSettings = <HTMLInputElement>(document.getElementById("developerSettingsDiv"));
+const noHapticsSetting = <HTMLInputElement>(document.getElementById("none-option"));
+const haply2diySetting =  <HTMLInputElement>(document.getElementById("haply-option"));
 
-// if (toggleButton) {
-//   toggleButton?.addEventListener("click", showDeveloperSettings);
-// } else {
-//   console.warn('Could not find toggle button with ID "toggle"');
-// }
+if (toggleButton) {
+  toggleButton?.addEventListener("click", showDeveloperSettings);
+} else {
+  console.warn('Could not find toggle button with ID "toggle"');
+}
 
-// function showDeveloperSettings() {
-// if (toggleButton.checked) {
-//     developerSettings.style.display = "block";
-//   } else {
-//     developerSettings.style.display = "none";
-//   }
-// }
+function showDeveloperSettings() {
+if (toggleButton.checked && chromeAgent===true) {
+    developerSettings.style.display = "block";
+  } else {
+    developerSettings.style.display = "none";
+  }
+}
+
 
 function customUrlCheck(){
   browser.storage.sync.get({
@@ -70,8 +73,8 @@ function saveOptions() {
     mcgillServer: mcgillServerSetting.checked,
     customServer: customServerSetting.checked,
     developerMode: toggleButton.checked,
-    //noHaptics: noHapticsSetting.checked,
-    //haply2diy: haply2diySetting.checked
+    noHaptics: noHapticsSetting.checked,
+    haply2diy: haply2diySetting.checked
   }),
     (function () {
     customUrlCheck();
@@ -90,8 +93,8 @@ function restore_options() {
       customServer:false,
       previousToggleState:false,
       developerMode: false,
-      //noHaptics:true,
-      //haply2diy:false
+      noHaptics:true,
+      haply2diy:false
     })
     .then((items) => {
       (<HTMLInputElement>document.getElementById("input-url")).value =
@@ -99,18 +102,18 @@ function restore_options() {
         mcgillServerSetting.checked = items["mcgillServer"];
         customServerSetting.checked = items["customServer"];
         toggleButton.checked = items["developerMode"];
-        //noHapticsSetting.checked= items["noHaptics"];
-        //haply2diySetting.checked= items["haply2diy"];
+        noHapticsSetting.checked= items["noHaptics"];
+        haply2diySetting.checked= items["haply2diy"];
 
-        // if (toggleButton.checked) {
-        //   developerSettings.style.display = "block"; 
-        // }
+        if (toggleButton.checked && chromeAgent===true) {
+          developerSettings.style.display = "block"; 
+        }
     }); 
 }
 
 document.addEventListener("DOMContentLoaded", restore_options);
 
-const submit = document.getElementById("preferences-submit");
+const submit = <HTMLInputElement>(document.getElementById("preferences-submit"));
 
 if (submit) {
   submit.textContent = browser.i18n.getMessage("savePreferences");


### PR DESCRIPTION
This PR removes Haptics for browsers that do not support webserials. When debugger is turned on, no haptics options should show for browsers that do not support webserials

Tests done:
Unpacked extension in Firefox(Does not support webserials)
<img width="1005" alt="Screen Shot 2022-02-14 at 6 48 58 PM" src="https://user-images.githubusercontent.com/55144801/153966552-82b7a26c-e0d1-4ac5-993a-d8753c91ce1a.png">

Unpacked extension in Chrome(supports webserials)
<img width="911" alt="Screen Shot 2022-02-14 at 6 52 54 PM" src="https://user-images.githubusercontent.com/55144801/153966625-806e7e5c-6137-4671-bc5a-330f5a857615.png">
