### PR TITLE
Stop Segment Audio Playback on Button Press

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -36,8 +36,8 @@
         "description": "Selection option to play through the entire rendering."
     },
     "segmentAudioButton": {
-        "message": "Play",
-        "description": "Label for playing audio renderings of selected audio segment."
+        "message": "Play/Stop",
+        "description": "Label for playing and stopping audio renderings of selected audio segment."
     },
     "audioRenderingsLabel": {
         "message": "Audio (Specialized renderings, best experienced with stereo headphones)",

--- a/src/info/info.ts
+++ b/src/info/info.ts
@@ -140,6 +140,12 @@ port.onMessage.addListener(async (message) => {
             button.classList.add("btn", "btn-secondary");
             selectDiv.append(button);
 
+            const download = document.createElement("a");
+            download.setAttribute("href", rendering["data"]["audioFile"] as string);
+            download.setAttribute("download", "rendering-" + count + "-" + request_uuid);
+            download.textContent = "Download Audio File";
+            contentDiv.append(download);
+
             const audioBuffer = await fetch(rendering["data"]["audioFile"] as string).then(resp => {
                 return resp.arrayBuffer();
             }).then(buffer => {


### PR DESCRIPTION
This adds a "stop" feature to the former play button for segment audio, updates the schemas submodule (this has no change on generated files), and adds a download link to the segment audio renderings. This resolves #151.

Functionality is as follows:
- If no audio is playing, then pressing the button starts the selected segment, which will play until the segment ends if not interacted with.
- If audio is playing, then pressing the button stops the ongoing playback.