### PR TITLE
Firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
     "start": "parcel serve src/manifest.json --target webext-dev --dist-dir build",
     "clean": "rm -rf build",
     "pack": "npm run clean && parcel build src/manifest.json --target webext-prod",
+    "pack:chromium": "mv src/manifest.json src/manifest.json.bak && jq -r 'del( .browser_specific_settings )' src/manifest.json.bak > src/manifest.json && npm run clean && parcel build src/manifest.json --target webext-prod && rm src/manifest.json && mv src/manifest.json.bak src/manifest.json",
     "prestart": "(cd schemas && json2ts -i '*.json' -o ../src/types)",
     "build:ff": "npm run pack && web-ext build -s build -a dist",
-    "build:chromium": "npm run pack && chromium --pack-extension=build --pack-extension-key=$PATH_TO_CHROME_KEY && mkdir -p dist && mv build.crx dist/IMAGE-chrome.crx"
+    "build:chromium": "npm run pack:chromium && chromium --pack-extension=build --pack-extension-key=$PATH_TO_CHROME_KEY && mkdir -p dist && mv build.crx dist/IMAGE-chrome.crx"
   },
   "devDependencies": {
     "@parcel/config-webextension": "^2.2.1",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extensionName__",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "__MSG_extensionDescription__",
     "homepage_url": "https://image.a11y.mcgill.ca",
     "default_locale": "en",
@@ -21,6 +21,13 @@
         "browser_style": true,
         "chrome_style": true
     },
+
+    "browser_specific_settings": {
+        "gecko": {
+          "id": "image@cim.mcgill.ca",
+          "strict_min_version": "42.0"
+        }
+      },      
 
     "permissions": [
         "contextMenus",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -24,7 +24,7 @@
 
     "browser_specific_settings": {
         "gecko": {
-          "id": "image@cim.mcgill.ca",
+          "id": "image@image.extension.ca",
           "strict_min_version": "42.0"
         }
       },      


### PR DESCRIPTION
This PR makes the extension adds functionality to Firefox version of the extension. 
NOTE: It creates a build for browsers that do not support browser specific settings (eg Chrome) by running "npm run pack:chromium" 
npx web-ext run -s will run a build with browser specific settings for Firefox

Tests done:
Ran the different builds and unpacked them in the respective browsers. The extension works without throwing a warning for Firefox and Chrome