### PR TITLE
Default text and audio options

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -35,7 +35,7 @@ function getAllStorageSyncData() {
     noHaptics: true,
     haply2diy: false,
     audio: true,
-    text: false,
+    text: true,
     processItem: "",
     requestItem: "",
     mweItem: ""

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -105,7 +105,7 @@ function restore_options() {
       noHaptics:true,
       haply2diy:false,
       audio:true,
-      text:true
+       text:true
     })
     .then((items) => {
       (<HTMLInputElement>document.getElementById("input-url")).value =

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -105,7 +105,7 @@ function restore_options() {
       noHaptics:true,
       haply2diy:false,
       audio:true,
-      text:false
+      text:true
     })
     .then((items) => {
       (<HTMLInputElement>document.getElementById("input-url")).value =


### PR DESCRIPTION
This PR makes text and audio options default upon unloading an extension

Tests done:
Unpacked extension on clean browser: Text and Audio renderings where default upon rendering an image