### PR TITLE
Update the no rendering message

### DIFF
--- a/src/errors/no_renderings.html
+++ b/src/errors/no_renderings.html
@@ -5,7 +5,7 @@
     </head>
     <body>
         <p>
-            IMAGE is unable to render this graphic. If you would like to let us know about this, please send a link to this graphic and a short description of the problem via email: <a href = "mailto: image@cim.mcgill.ca"> image@cim.mcgill.ca</a>.
+            IMAGE is unable to render this graphic. If you would like to let us know about this, please send a link to this graphic and a short description of the problem via email: <a href = "mailto: image@cim.mcgill.ca"> image@cim.mcgill.ca</a> or report bugs using <a id="feedback-a" href="../info/feedback.html" target="_blank">our feedback form</a>.
             Please ensure that the graphic you are sending contains no personal information.
         </p>
         <button id="closing-button" type="button" > Close Window </button>


### PR DESCRIPTION
This Pr aim to fix [Issue 204](https://github.com/Shared-Reality-Lab/IMAGE-browser/issues/204). It allow the user to mark the request as OK for us to look at, and fill out the feedback form to let us know any other detail, when no rendering is returned.

<img width="868" alt="Screen Shot 2022-05-11 at 12 35 59 PM" src="https://user-images.githubusercontent.com/77598617/167902721-873b41fd-26b4-4abf-8436-1e867ec09a56.png">
