### PR TITLE
map-preprocessor

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -99,7 +99,7 @@
         "description": "Label for button to get map renderings"
     },
     "getMapPreprocessorResponse": {
-        "message": "Get Map Preprocessor Response",
-        "description": "Label for button to get Preprocess Map Renderings"
+        "message": "Get IMAGE preprocessed data",
+        "description": "Label for button to get Map Preprocessor Response"
     }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -97,5 +97,9 @@
     "getMapRendering": {
         "message": "Get IMAGE Map Rendering",
         "description": "Label for button to get map renderings"
+    },
+    "getMapPreprocessorResponse": {
+        "message": "Get Map Preprocessor Response",
+        "description": "Label for button to get Preprocess Map Renderings"
     }
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -257,7 +257,7 @@ async function updateDebugContextMenu() {
     tabs.then(function (tabs) {
       for (var i = 0; i < tabs.length; i++) {
           browser.tabs.insertCSS(tabs[i].id, {
-            code: `#preprocessor-map-button{
+            code: `button#preprocessor-map-button{
               display: inline-block;
             }`
           });
@@ -296,7 +296,7 @@ async function updateDebugContextMenu() {
       for (var i = 0; i < tabs.length; i++) {
         browser.tabs.insertCSS(tabs[i].id, {
           code: `
-          #preprocessor-map-button{
+          button#preprocessor-map-button{
             display: none;
           }`
         });

--- a/src/background.ts
+++ b/src/background.ts
@@ -251,8 +251,18 @@ async function updateDebugContextMenu() {
   let items = await getAllStorageSyncData();
   showDebugOptions = items["developerMode"];
   previousToggleState = items["previousToggleState"];
+  let tabs = browser.tabs.query({})
 
   if (showDebugOptions) {
+    tabs.then(function (tabs) {
+      for (var i = 0; i < tabs.length; i++) {
+          browser.tabs.insertCSS(tabs[i].id, {
+            code: `#preprocessor-map-button{
+              display: inline-block;
+            }`
+          });
+      }},function(){});
+
     if (items["processItem"] === "" && items["requestItem"] === "") {
       browser.contextMenus.create({
         id: "preprocess-only",
@@ -281,7 +291,16 @@ async function updateDebugContextMenu() {
     browser.storage.sync.set({
       processItem: "",
       requestItem: "",
-    })
+    });
+    tabs.then(function (tabs) {
+      for (var i = 0; i < tabs.length; i++) {
+        browser.tabs.insertCSS(tabs[i].id, {
+          code: `
+          #preprocessor-map-button{
+            display: none;
+          }`
+        });
+      }},function(){});
   }
 }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -39,7 +39,8 @@
     },
     "content_scripts": [{
         "matches": ["<all_urls>"],
-        "js": ["content.ts"]
+        "js": ["content.ts"],
+        "css": ["styles.css"]
     }],
     "web_accessible_resources": [
         "info/*.ts",

--- a/src/maps/maps-utils.ts
+++ b/src/maps/maps-utils.ts
@@ -1,6 +1,6 @@
 import browser from "webextension-polyfill";
 import { IMAGERequest } from "../types/request.schema";
-import { getRenderers } from "../utils";
+import { getAllStorageSyncData, getRenderers } from "../utils";
 import { v4 as uuidv4 } from "uuid";
 
 export function processIMAGEMaps(document: Document, port: browser.Runtime.Port){
@@ -9,54 +9,24 @@ export function processIMAGEMaps(document: Document, port: browser.Runtime.Port)
             // domains list at www.google.com/supported_domains, but this is too long to manually put
             if (map.hasAttribute("src") && (/google.[\w\.]+\/maps/.test(map.src))) {
                 map.setAttribute("tabindex", "0");
-                let map_button = document.createElement("button");
-                map_button.innerText = browser.i18n.getMessage("getMapRendering");
+                let mapButton = document.createElement("button");
+
+                mapButton.innerText = browser.i18n.getMessage("getMapRendering");
+                let preprocessorMapButton = document.createElement("button");
+                preprocessorMapButton.innerText = browser.i18n.getMessage("getMapPreprocessorResponse");
                 // Get all the information about our found map and store the info. Then create a button to render the map
-                map_button.addEventListener("click", () => {
-                    const serializer = new XMLSerializer();
-                    let src = map.getAttribute("src");
-                    let q, lat, lon, zoom;
-                    let maptype = "roadmap";
-                    if(src?.includes("&q=")){ // assume src is not null and then look for a query string
-                       let i1 = src.indexOf("&q=") + 3;
-                       let i2 = src.indexOf("&", i1) == -1 ? src.length : src.indexOf("&", i1); // query either goes to the end or there is another header
-                       q = src.substring(i1, i2);
-                    }
-                    if(src?.includes("&center=")){ // try to find center of map
-                        let i1 = src.indexOf("&center=") + 8;
-                        let i2 = src.indexOf("&", i1) == -1 ? src.length : src.indexOf("&", i1);
-                        let center = src.substring(i1, i2);
-                        lat = center.split(",")[0];
-                        lon = center.split(",")[1];
-                    }
-                    if(src?.includes("&zoom=")){ // try to find zoom of map
-                        let i1 = src.indexOf("&zoom=") + 6;
-                        let i2 = src.indexOf("&", i1) == -1 ? src.length : src.indexOf("&", i1);
-                        zoom = src.substring(i1, i2);
-                    }
-                    if(src?.includes("&maptype=satellite")){ // only important map type right now is satellite
-                        maptype = "satellite";
-                    }
-                    if(lat && lon){ // only send the resource request if we have a lat and lon
-                        console.debug("Sending map resource request");
-                        port.postMessage({
-                            "type": "mapResource",
-                            "context": map ? serializer.serializeToString(map) : null,
-                            "coordinates": [parseFloat(lat), parseFloat(lon)],
-                            "toRender": "full"
-                        });
-                    }else if(q){ // if we don't have a lat and lon, but we have a query, send a search request
-                        console.debug("Sending map search request");
-                        port.postMessage({
-                            "type": "mapSearch",
-                            "context": map ? serializer.serializeToString(map) : null,
-                            "placeID": q,
-                            "toRender": "full"
-                        });
-                    }
+                mapButton.addEventListener("click", () => {
+                    sendMapRequest(port, map, "full");
                 });
-                map_button.setAttribute("tabindex", "0");
-                map.insertAdjacentElement("afterend", map_button);
+
+                mapButton.setAttribute("tabindex", "0");
+                map.insertAdjacentElement("afterend", mapButton);
+
+                preprocessorMapButton.setAttribute("id", "preprocessor-map-button");
+                preprocessorMapButton.addEventListener("click",()=>{
+                    sendMapRequest(port, map, "preprocess");
+                });
+                mapButton.insertAdjacentElement("afterend", preprocessorMapButton);
             }
         }
     });
@@ -90,3 +60,48 @@ export async function generateMapSearchQuery(message: { context: string, placeID
       "renderers": renderers
   } as IMAGERequest;
 }
+
+function sendMapRequest(port: browser.Runtime.Port, map: HTMLIFrameElement, toRender: String){
+    const serializer = new XMLSerializer();
+    let src = map.getAttribute("src");
+    let q, lat, lon, zoom;
+    let maptype = "roadmap";
+    if(src?.includes("&q=")){ // assume src is not null and then look for a query string
+        let i1 = src.indexOf("&q=") + 3;
+        let i2 = src.indexOf("&", i1) == -1 ? src.length : src.indexOf("&", i1); // query either goes to the end or there is another header
+        q = src.substring(i1, i2);
+    }
+    if(src?.includes("&center=")){ // try to find center of map
+        let i1 = src.indexOf("&center=") + 8;
+        let i2 = src.indexOf("&", i1) == -1 ? src.length : src.indexOf("&", i1);
+        let center = src.substring(i1, i2);
+        lat = center.split(",")[0];
+        lon = center.split(",")[1];
+    }
+    if(src?.includes("&zoom=")){ // try to find zoom of map
+        let i1 = src.indexOf("&zoom=") + 6;
+        let i2 = src.indexOf("&", i1) == -1 ? src.length : src.indexOf("&", i1);
+        zoom = src.substring(i1, i2);
+    }
+    if(src?.includes("&maptype=satellite")){ // only important map type right now is satellite
+        maptype = "satellite";
+    }
+    if(lat && lon){ // only send the resource request if we have a lat and lon
+        console.debug("Sending map resource request");
+        port.postMessage({
+            "type": "mapResource",
+            "context": map ? serializer.serializeToString(map) : null,
+            "coordinates": [parseFloat(lat), parseFloat(lon)],
+            "toRender": toRender
+        });
+    }else if(q){ // if we don't have a lat and lon, but we have a query, send a search request
+        console.debug("Sending map search request");
+        port.postMessage({
+            "type": "mapSearch",
+            "context": map ? serializer.serializeToString(map) : null,
+            "placeID": q,
+            "toRender": toRender
+        });
+    }
+}
+

--- a/src/maps/maps-utils.ts
+++ b/src/maps/maps-utils.ts
@@ -1,6 +1,6 @@
 import browser from "webextension-polyfill";
 import { IMAGERequest } from "../types/request.schema";
-import { getAllStorageSyncData, getRenderers } from "../utils";
+import { getRenderers } from "../utils";
 import { v4 as uuidv4 } from "uuid";
 
 export function processIMAGEMaps(document: Document, port: browser.Runtime.Port){
@@ -20,13 +20,19 @@ export function processIMAGEMaps(document: Document, port: browser.Runtime.Port)
                 });
 
                 mapButton.setAttribute("tabindex", "0");
-                map.insertAdjacentElement("afterend", mapButton);
+                let buttonContainer = document.createElement("div");
+                buttonContainer.style.display = "flex";
+                buttonContainer.style.marginTop = "5px";
 
                 preprocessorMapButton.setAttribute("id", "preprocessor-map-button");
+
                 preprocessorMapButton.addEventListener("click",()=>{
                     sendMapRequest(port, map, "preprocess");
                 });
-                mapButton.insertAdjacentElement("afterend", preprocessorMapButton);
+                buttonContainer.appendChild(mapButton);
+                buttonContainer.appendChild(preprocessorMapButton);
+                map.insertAdjacentElement("afterend", buttonContainer);
+
             }
         }
     });

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,4 @@
+#preprocessor-map-button{
+    display: none;
+    margin-left: 5px;
+}


### PR DESCRIPTION
The PR provides a fix for issue https://github.com/Shared-Reality-Lab/IMAGE-browser/issues/227.
If debug mode is enabled, an extra button will appear. Once the user clicks the button, the preprocessor response (json) will be downloaded:
 
![image](https://user-images.githubusercontent.com/51749136/177017937-57f75b13-8ddc-43ae-81e1-3e66c1f6214b.png)

If debug mode is disabled, this button will not be visisble:

![image](https://user-images.githubusercontent.com/51749136/177017959-78b84262-2536-4421-8e0e-b5a0fc5b793f.png)

@jeffbl , @JRegimbal  Note that I am open to suggestions here, please let me know if there is a better way to implement this functionality. 
