### PR TITLE
fix: haply not supported message

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -75,6 +75,10 @@
         "message": "Haply 2diy",
         "description": "Label for Haply 2diy option."
     },
+    "Haply2diyNotSupported": {
+        "message": "Haply 2diy: Unavailable since this browser does not support Web Serial.",
+        "description": "Label for Haply 2diy option when it is not supported by browser"
+    },
     "preprocessMap": {
         "message": "Get Preprocessed Map Data",
         "description": "Fetch preprocessed JSON data for a map without renderings."

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -49,7 +49,15 @@ if (toggleButton) {
 }
 
 function showDeveloperSettings() {
-if (toggleButton.checked && navigatorSerial !== undefined) {
+  if(toggleButton.checked){
+    let haplyLabel = document.querySelector("#Haply2diy");
+    if(navigatorSerial){
+      haplyLabel!.textContent = browser.i18n.getMessage("Haply2diy");
+      (document.getElementById("haply-option") as HTMLInputElement)!.disabled = false;
+    } else {
+      haplyLabel!.textContent = browser.i18n.getMessage("Haply2diyNotSupported");
+      (document.getElementById("haply-option") as HTMLInputElement)!.disabled = true;
+    }
     developerSettings.style.display = "block";
   } else {
     developerSettings.style.display = "none";


### PR DESCRIPTION
resolves #237 . It adds a message when browser does not support web serial. The radio button is also disabled , thus cannot be selected.
![image](https://user-images.githubusercontent.com/51749136/227657081-0a5ea5e2-bdbc-4ae1-8eb0-4a9f8003d950.png)
