### PR TITLE
fix overleaf text insertion bug

### DIFF
--- a/src/buttons.js
+++ b/src/buttons.js
@@ -78,6 +78,12 @@ function processGraphics() {
   let images = document.getElementsByTagName("img");
   /** add a button below each image - visible to screen reader only */
   for (let image of images) {
+
+    // ignore detected images with no src attribute, e.g., on Overleaf
+    if (!image.hasAttribute("src")) {
+      continue;
+    }
+
     let button = document.createElement("button");
     button.innerText = "Interpret graphic with IMAGE";
     /* Make the button hidden depending on the config */


### PR DESCRIPTION
Resolves #355 by ignoring any detected elements with the img tag that don't have an src attribute. Also tested with NVDA and seems to work fine.