### PR TITLE
fix: fix image popup trigger

### DIFF
--- a/src/buttons.js
+++ b/src/buttons.js
@@ -37,6 +37,7 @@ function processCharts() {
         document.getElementById(divId).style.height = "max-content";
         divChartMap[divId] = chart
         let chartButton = document.createElement("button");
+        chartButton.type = "button";
         // Set button text based on language (this is a workaround)
         let chartButtonText;
         if (navigator.language === 'fr')
@@ -85,6 +86,7 @@ function processGraphics() {
     }
 
     let button = document.createElement("button");
+    button.type = "button";
     button.innerText = "Interpret graphic with IMAGE";
     /* Make the button hidden depending on the config */
     if (!buttons) {


### PR DESCRIPTION
resolves https://github.com/Shared-Reality-Lab/IMAGE-browser/issues/360. This was a common issue for all the webpages where HTML form contains a graphic. By default, when we add buttons for every graphic, they have a default behavior of submit. Hence, pressing Enter triggers IMAGE popup. Fix for this includes overriding type to "button" for the buttons added by the extension. 