### PR TITLE
Upgraded actions to v4 for node version 16

### DIFF
--- a/.github/workflows/ios-automate.yaml
+++ b/.github/workflows/ios-automate.yaml
@@ -13,10 +13,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         
       - name: Install Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '16'
           
@@ -30,7 +30,7 @@ jobs:
         run: xcrun safari-web-extension-converter ./build-chrome
       
       - name: Upload Xcode project
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: xcode-project
           path: "IMAGE Extension (Test)"


### PR DESCRIPTION
- The following actions use node12 which is deprecated and will be forced to run on node16.
- Changed actions/checkout, actions/setup-node, actions/upload-artifact version from v2 to v4.
