### PR TITLE
fix: options page bugs

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -87,12 +87,12 @@
         "message": "Language",
         "description": "Label for language selection menu."
     },
-    "automaticLanguage": {
-        "message": "Automatic",
+    "browserLanguage": {
+        "message": "Browser Language",
         "description": "Automatic language select option"
     },
     "languageWarning": {
-        "message": "Warning: In some cases, IMAGE results may appear in English or French instead of your chosen language due to technical limitations.",
+        "message": "Note: Languages other than French and English may not be fully supported.",
         "description": "Warning for language selection"
     },
     "cancelButton": {

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -83,12 +83,12 @@
         "message": "Langue",
         "description": "Étiquette pour le menu de sélection de la langue."
     },
-    "automaticLanguage": {
-        "message": "Automatique",
+    "browserLanguage": {
+        "message": "Langue du navigateur",
         "description": "Option de sélection pour la langue automatique."
     },
     "languageWarning": {
-        "message": "Avertissement : Dans quelques cas, les résultats d'IMAGE peuvent apparaître en anglais ou en français au lieu de la langue choisie, en raison de limitations techniques.",
+        "message": "Remarque : les langues autres que le français et l’anglais peuvent ne pas être entièrement prises en charge.",
         "description": "Avertissement pour la selection de la langue."
     },
     "cancelButton": {

--- a/src/info/info.css
+++ b/src/info/info.css
@@ -31,11 +31,11 @@ footer{
     height: auto;
 }
 
-/* .svg-container{
+.svg-container{
     position: absolute;
     top:0;
     left:0;
-} */
+}
 
 
 .render-img, .render-svg{

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -180,7 +180,7 @@
    gap: 1vw;
  }
 
- #monarch-options{
+ #monarch-options, #debugText{
   display: none;
  }
  

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -10,7 +10,7 @@
     <div class="options-section">
         <button type="button" data-bs-toggle="collapse" data-bs-target="#interpretation-div"
             class="localisation btn btn-light" id="interpretationOptions"></button>
-        <div id="interpretation-div" class="settings-div">
+        <div id="interpretation-div" class="settings-div show">
             <div class="browser-style">
                 <input type="checkbox" id="audio-renderings" name="audio-renderings">
                 <label class="localisation" for="audioRenderingsLabel" id="audioRenderingsLabel"></label>
@@ -24,11 +24,11 @@
     <div class="options-section">
         <button type="button" data-bs-toggle="collapse" data-bs-target="#language-div"
             class="localisation btn btn-light" id="languageOptions"></button>
-        <div id="language-div" class="settings-div">
+        <div id="language-div" class="settings-div show">
             <div>
                 <label class="localisation" for="languageSelectionLabel" id="languageSelectionLabel"></label>
                 <select name="language-selection" id="language-selection">
-                    <option class="localisation" id="automaticLanguage" value="auto"></option>
+                    <option class="localisation" id="browserLanguage" value="auto"></option>
                     <option value="en">English</option>
                     <option value="fr">Français</option>
                 </select>
@@ -46,7 +46,7 @@
     <div class="options-section">
         <button type="button" data-bs-toggle="collapse" data-bs-target="#server-div" class="localisation btn btn-light"
             class="localisation" id="serverOptions"></button>
-        <div id="server-div" class="settings-div">
+        <div id="server-div" class="settings-div show">
             <div>
                 <input type="radio" id="mcgill-server" name="serverOptions" checked>
                 <label class="localisation" for="mcgillServerLabel" id="mcgillServerLabel"></label>
@@ -63,7 +63,7 @@
     <div class="options-section">
         <button type="button" data-bs-toggle="collapse" data-bs-target="#monarch-div" class="localisation btn btn-light"
             class="localisation" id="hapticDevices"></button>
-        <div id="monarch-div" class="settings-div">
+        <div id="monarch-div" class="settings-div show">
             <div id="monarch-header">
                 <label class="localisation" id="monarchContainerHeading"></label>
                 <div class="toggle-container">

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -52,6 +52,12 @@ monarchSettings?.addEventListener("change", (event)=>{
   monarchOptions.style.display = monarchSettings.checked ? "block" : "none";
 });
 
+languageSetting?.addEventListener("change", (event)=>{
+  let languageWarning= <HTMLElement>document.querySelector("#languageWarning");
+  const target = event.target as HTMLSelectElement;
+  languageWarning.style.display = target?.value === "auto" ? "inline-block" : "none";
+});
+
 
 function optionsCheck(){
   browser.storage.sync.get({
@@ -137,6 +143,10 @@ function restore_options() {
         if (developerSettings.checked &&  navigatorSerial !== undefined) {
           developerSettings.style.display = "block"; 
         }
+        let monarchOptions= <HTMLElement>document.querySelector("#monarch-options");
+        monarchOptions.style.display = monarchSettings.checked ? "block" : "none";
+        let debugText = <HTMLElement>document.querySelector("#debugText");
+        debugText.style.display = developerSettings.checked ? "block" : "none";
     });
     if(extVersion === "development"){
       document.getElementById("extensionPreferences")!.innerText += process.env.SUFFIX_TEXT;


### PR DESCRIPTION
Resolves #405 
This pull request introduces updates to language-related features, UI behavior, and rendering logic, along with minor CSS and HTML adjustments. The most significant changes include renaming the "Automatic" language option to "Browser Language," improving language warning messages, and adding functionality for handling tactile SVG renderings.

### Language and Localization Updates:
* Renamed the "Automatic" language selection option to "Browser Language" in both English (`src/_locales/en/messages.json`) and French localization files (`src/_locales/fr/messages.json`). Updated descriptions accordingly. [[1]](diffhunk://#diff-a92a5a80239a5d0041533d117096d8a136752c0ab64cd397b0e7e9ad9cb04412L90-R95) [[2]](diffhunk://#diff-b1e4cb45cb3a29e085d43781bbc62ddc48e9a6a9d759f543d5c6ea1a1c927177L86-R91)
* Revised language warning messages to clarify that only English and French are fully supported. [[1]](diffhunk://#diff-a92a5a80239a5d0041533d117096d8a136752c0ab64cd397b0e7e9ad9cb04412L90-R95) [[2]](diffhunk://#diff-b1e4cb45cb3a29e085d43781bbc62ddc48e9a6a9d759f543d5c6ea1a1c927177L86-R91)
* Updated the language dropdown in `src/options/options.html` to reflect the new "Browser Language" option.
* Added a listener in `src/options/options.ts` to display a warning message when "Browser Language" is selected.

### Rendering and Interaction Enhancements:
* Added logic in `src/info/info.ts` to handle tactile SVG renderings by sending requests to the background script when the header is clicked.
* Fixed the position of the SVG container when `renderImg.src` is not available, ensuring proper layout for map renderings.

### UI and CSS Adjustments:
* Made all settings sections in `src/options/options.html` (e.g., language, server, monarch) visible by default by adding the `show` class. [[1]](diffhunk://#diff-594c44a28df5453d166af1cfc08191e04d1a2576a04161c773b2ea80e2dac86cL13-R13) [[2]](diffhunk://#diff-594c44a28df5453d166af1cfc08191e04d1a2576a04161c773b2ea80e2dac86cL49-R49) [[3]](diffhunk://#diff-594c44a28df5453d166af1cfc08191e04d1a2576a04161c773b2ea80e2dac86cL66-R66)
* Updated `src/options/options.css` to ensure `#monarch-options` and `#debugText` are hidden by default.
* Restored UI elements' visibility based on user settings in `src/options/options.ts`.

### Codebase Maintenance:
* Un-commented and restored the `.svg-container` CSS rule in `src/info/info.css`.
* Added a new utility import `getContext` in `src/info/info.ts` for enhanced rendering logic.