### PR TITLE
fix: reset maps option after select

### DIFF
--- a/src/maps/maps-utils.ts
+++ b/src/maps/maps-utils.ts
@@ -79,7 +79,10 @@ export function processMap(port: browser.Runtime.Port, map: any, origin: string,
                 default:
                     break;
             }
-        });    
+        });
+        selectElement.addEventListener("focus",(event)=> {
+            selectElement.selectedIndex = 0;
+        });   
         let parentElement = map;
         // handle cases when map(image) is embedded in an anchor tag - necessary to fix the layout
         if (map.parentNode.nodeName.toLowerCase() === "a" ){


### PR DESCRIPTION
resolves https://github.com/Shared-Reality-Lab/IMAGE-server/issues/1044
This pull request introduces a small change to the `processMap` function in `src/maps/maps-utils.ts`. It adds a `focus` event listener to reset the `selectedIndex` of a `selectElement` to `0` whenever the element gains focus.