### PR TITLE
fix: multiple chart buttons

### DIFF
--- a/src/buttons.js
+++ b/src/buttons.js
@@ -182,6 +182,6 @@ document.onreadystatechange = function () {
   }
 }
 
-window.addEventListener('locationchange', function () {
-  setTimeout(processCharts, 1000);
-})
+// window.addEventListener('locationchange', function () {
+//   setTimeout(processCharts, 1000);
+// })


### PR DESCRIPTION
Resolves https://github.com/Shared-Reality-Lab/IMAGE-server/issues/1023
This pull request includes a minor change in `src/buttons.js` to comment out an event listener for `locationchange`. This disables the `processCharts` function from being triggered after a location change.

* [`src/buttons.js`](diffhunk://#diff-f329156fd4cb0ab46031758b0fc580e04543e36fb583e90e2c943fae8efaa90bL185-R187): Commented out the `window.addEventListener('locationchange')` block, which previously invoked `processCharts` with a delay of 1 second.