### PR TITLE
fix: tactile renderings error popup

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -226,7 +226,23 @@ async function handleMessage(p: Runtime.Port, message: any) {
             console.log("message", message);
             if (message["redirectToTAT"]) {
               console.log("Received TAT data in background script");
-              let tactileResponse = json.renderings.filter((rendering) => (rendering.type_id == RENDERERS.tactileSvg))
+              let tactileResponse = json.renderings.filter((rendering) => (rendering.type_id == RENDERERS.tactileSvg));
+              if (tactileResponse.length === 0) {
+                console.error("No Tactile SVG rendering found in response");  
+                await windowsPanel ? browser.windows.create({
+                  type: "panel",
+                  url: 'errors/no_renderings.html?uuid=' +
+                    encodeURIComponent((query['request_uuid'] || '')) + "&hash=" +
+                    encodeURIComponent(hash(query)) + "&serverURL=" +
+                    encodeURIComponent(serverUrl.toString())
+                }) : browser.tabs.create({
+                  url: 'errors/no_renderings.html?uuid=' +
+                    encodeURIComponent((query['request_uuid'] || '')) + "&hash=" +
+                    encodeURIComponent(hash(query)) + "&serverURL=" +
+                    encodeURIComponent(serverUrl.toString())
+                });
+                return;
+              }
               let tactileSvgGraphic = tactileResponse[0].data.graphic as string;
               //console.log("Tactile Response", tactileSvgGraphic);
               let encodedSvg = tactileSvgGraphic.split("data:image/svg+xml;base64,")[1];


### PR DESCRIPTION
resolves https://github.com/Shared-Reality-Lab/IMAGE-browser/issues/411
This pull request introduces error handling for cases where no Tactile SVG renderings are found in the response within the `handleMessage` function in `src/background.ts`. It ensures that users are notified appropriately through either a new browser panel or tab displaying an error page.

### Error handling improvements:

* Added a check for empty `tactileResponse` array and logged an error message when no Tactile SVG renderings are found.
* Implemented logic to open an error page (`errors/no_renderings.html`) in either a browser panel or tab, depending on the availability of `windowsPanel`. The page includes query parameters with encoded UUID, hash, and server URL for context.