### PR TITLE
fix: invisible button bug

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -188,9 +188,9 @@ async function handleMessage(p: Runtime.Port, message: Message) {
       }
       else {
         const graphicBlobStr = await blobToBase64(blob) as string;
-        if (checkImageSizeMessage.context && checkImageSizeMessage.url && checkImageSizeMessage.dims) {
+        if (checkImageSizeMessage.url && checkImageSizeMessage.dims) {
           query = await generateQuery({
-            context: checkImageSizeMessage.context,
+            context: checkImageSizeMessage.context || "",
             url: checkImageSizeMessage.url,
             dims: checkImageSizeMessage.dims,
             graphicBlob: graphicBlobStr


### PR DESCRIPTION
resolves #434
This pull request makes a minor adjustment to the logic for handling image size check messages in `src/background.ts`. The change ensures that the `context` parameter passed to `generateQuery` is always a string, defaulting to an empty string if not provided. This helps prevent potential errors when `context` is undefined.