### PR TITLE
iOS feedback form functionality fix

### DIFF
--- a/Safari.md
+++ b/Safari.md
@@ -90,7 +90,6 @@ While using the IMAGE browser extension on Safari, please be aware of the follow
 
 - The extension does not produce any sound when an IMAGE request is sent.
 - The feedback link is missing when an IMAGE result is received for maps and charts.
-- On the Feedback page, selecting "(Optional) I consent to the IMAGE project saving this request and the responses associated with it under the conditions described above" may cause the "open form" button to not work as intended.
 - Connecting haptic devices is not supported.
 - iOS only: The extension will become unresponsive and require a manual restart everytime Safari is restarted.
 

--- a/src/feedback/feedback.ts
+++ b/src/feedback/feedback.ts
@@ -59,19 +59,20 @@ formButton?.addEventListener("click", () => {
            console.error(err);
            alert(browser.i18n.getMessage("saveDataUnknownError"));
         }).then(() => {
+            // Navigate current window for iOS compatibility
             if (lang === 'fr') {
-                window.open("https://docs.google.com/forms/d/e/1FAIpQLSd3R9pit99xe2ZQUdavidKjJsvD0220tITGJ3LuEewuYcCIVQ/viewform?usp=pp_url&entry.1541900668=" + request_uuid);
+                window.location.href = "https://docs.google.com/forms/d/e/1FAIpQLSd3R9pit99xe2ZQUdavidKjJsvD0220tITGJ3LuEewuYcCIVQ/viewform?usp=pp_url&entry.1541900668=" + request_uuid;
             }
             else {
-                window.open("https://docs.google.com/forms/d/e/1FAIpQLSdZJH8xi_cUQK8MdR3cty1wZVB08WLGozzdKmRZqG-2q9zRaA/viewform?usp=pp_url&entry.1541900668=" + request_uuid);
+                window.location.href = "https://docs.google.com/forms/d/e/1FAIpQLSdZJH8xi_cUQK8MdR3cty1wZVB08WLGozzdKmRZqG-2q9zRaA/viewform?usp=pp_url&entry.1541900668=" + request_uuid;
             }
         });
     } else {
         if (lang === 'fr') {
-            window.open("https://docs.google.com/forms/d/e/1FAIpQLSd3R9pit99xe2ZQUdavidKjJsvD0220tITGJ3LuEewuYcCIVQ/viewform?usp=pp_url");
+            window.location.href = "https://docs.google.com/forms/d/e/1FAIpQLSd3R9pit99xe2ZQUdavidKjJsvD0220tITGJ3LuEewuYcCIVQ/viewform?usp=pp_url";
         }
         else {
-            window.open("https://docs.google.com/forms/d/e/1FAIpQLSdZJH8xi_cUQK8MdR3cty1wZVB08WLGozzdKmRZqG-2q9zRaA/viewform?usp=pp_url");
+            window.location.href = "https://docs.google.com/forms/d/e/1FAIpQLSdZJH8xi_cUQK8MdR3cty1wZVB08WLGozzdKmRZqG-2q9zRaA/viewform?usp=pp_url";
         }
     }
 });


### PR DESCRIPTION
## What

This was one of the following bugs from the list of Safari-only bugs:

_On the Feedback page, selecting "(Optional) I consent to the IMAGE project saving this request and the responses associated with it under the conditions described above" may cause the "open form" button to not work as intended. (I got your data has been recorded successfully instead)._

I noticed that this was actually iOS only, so I had to find a solution.

## Why was this happening

This was happening due to iOS devices not allowing open links on non-user registered actions. 

https://stackoverflow.com/questions/67836871/why-open-link-is-not-working-inside-a-async-handler-on-ipad-safari

Weirdly, the "Close" action on the alert was not enough to be considered a user registered action. I believe this was lenient for Safari though which is why it worked.

## How I fixed it

I fixed it by changing the logic from opening a new link to changing the existing one since iOS allows redirecting the user to a new site. This does obviously change the inherent logic from opening a new tab to redirection, but I hope that this solution is worthy enough to make the switch over.

## Demo

### Chrome

**Before**

https://github.com/user-attachments/assets/a4047272-60d4-4bc8-a5ed-0104cb09a1bb

**After**

https://github.com/user-attachments/assets/025e7ac0-6ae8-43bd-8f54-4fbcae63a4aa

### Safari

**Before**

https://github.com/user-attachments/assets/3732c316-dd9b-4de2-bd67-f74305b56414

**After**

https://github.com/user-attachments/assets/a492f482-576c-44a5-a605-febb8946421a

### iOS

**Before**

https://github.com/user-attachments/assets/139fa8d2-f127-4811-ac67-ab6e8764e245

**After**

https://github.com/user-attachments/assets/aed7c2a5-1817-4d2d-b9cd-c8ed3fdb964d


